### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![DockerHub](https://img.shields.io/badge/Docker-Hub-%23099cec?style=for-the-badge&logo=docker)](https://hub.docker.com/r/piratify/invitarr)
 ![Docker Pulls](https://img.shields.io/docker/pulls/piratify/invitarr?color=099cec&style=for-the-badge)
 [![Deploy](http://img.shields.io/badge/%E2%86%91_Deploy_to-Heroku-7056bf.svg?style=for-the-badge)](https://dashboard.heroku.com/new?template=https://github.com/Sleepingpirates/Invitarr-Heroku)
+[![Run on Repl.it](https://repl.it/badge/github/Sleepingpirates/Invitarr)](https://repl.it/github/Sleepingpirates/Invitarr)
 # Invitarr
 Plex Discord Bot to invite a user to a plex server once a user gets a certain role in discord. 
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).